### PR TITLE
Added Mezzio support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Laminas & Doctrine Encrypt Module
 
-Provides a Laminas & Doctrine 2 encryption module.
+Provides a Laminas & Doctrine 2 encryption module. With support for Mezzio.
 
 # Installation
 
@@ -36,6 +36,22 @@ If these are filled in, it works out of the box using [Halite](https://github.co
 
 However, must be said, at the moment of writing this ReadMe, the Halite module contains duplicate `const` declarations,
 as such, you must disable your `E_NOTICE` warnings in your PHP config :(
+
+## Mezzio
+
+When using Mezzio, you will want to add the ConfigProvider to your `config/config.php` file.
+```
+    \Keet\Encrypt\ConfigProvider::class,
+```
+
+When declaring the path to your entities, be sure to pass the path(s) as an array.
+```
+    'my_entity' => [
+        'class' => AnnotationDriver::class,
+        'cache' => 'array',
+        'paths' => [ __DIR__ . '/Entity' ],
+    ],
+```
 
 ## Annotation Examples
 

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "ext-sodium": "*",
         "doctrine/annotations": "^1.6",
         "doctrine/orm": "^2.6",
+        "doctrine/doctrine-module": "^4.1.1",
         "paragonie/halite": "^4.4",
         "paragonie/hidden-string": "^1.0",
         "laminas/laminas-modulemanager": "^2.8",

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace Keet\Encrypt;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Keet\Encrypt\Adapter\EncryptionAdapter;
+use Keet\Encrypt\Adapter\HashingAdapter;
+use Keet\Encrypt\Factory\Adapter\EncryptionAdapterFactory;
+use Keet\Encrypt\Factory\Adapter\HashingAdapterFactory;
+use Keet\Encrypt\Factory\Service\EncryptionServiceFactory;
+use Keet\Encrypt\Factory\Service\HashingServiceFactory;
+use Keet\Encrypt\Factory\Subscriber\EncryptionSubscriberFactory;
+use Keet\Encrypt\Factory\Subscriber\HashingSubscriberFactory;
+use Keet\Encrypt\Service\EncryptionService;
+use Keet\Encrypt\Service\HashingService;
+
+/**
+ * Config provider for Laminas Doctrine Encrypt config
+ */
+class ConfigProvider
+{
+    /**
+     * @return mixed[]
+     */
+    public function __invoke(): array
+    {
+        return [
+            'doctrine_factories' => $this->getDoctrineFactoryConfig(),
+            'doctrine' => $this->getDoctrine(),
+            'dependencies' => $this->getDependencies(),
+        ];
+    }
+
+    /**
+     * Factory mappings - used to define which factory to use to instantiate a particular doctrine service type
+     *
+     * @return mixed[]
+     */
+    public function getDoctrineFactoryConfig(): array
+    {
+        return [
+            'encryption' => EncryptionSubscriberFactory::class,
+            'hashing'    => HashingSubscriberFactory::class,
+        ];
+    }
+
+    /**
+     * Default configuration for Doctrine module
+     *
+     * Notice that the Doctrine event manager has key 'event_manager'
+     *
+     * @return mixed[]
+     */
+    public function getDoctrine(): array
+    {
+        return [
+            'encryption'   => [
+                'orm_default' => [
+                    'adapter' => 'encryption_adapter',
+                    'reader'  => AnnotationReader::class,
+                ],
+            ],
+            'hashing'      => [
+                'orm_default' => [
+                    'adapter' => 'hashing_adapter',
+                    'reader'  => AnnotationReader::class,
+                ],
+            ],
+            'event_manager' => [
+                'orm_default' => [
+                    'subscribers' => [
+                        'doctrine.encryption.orm_default',
+                        'doctrine.hashing.orm_default',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Return application-level dependency configuration
+     *
+     * @return mixed[]
+     */
+    public function getDependencies(): array
+    {
+        return [
+            'aliases'   => [
+                // Using aliases so someone else can use own adapter/factory
+                'encryption_adapter' => EncryptionAdapter::class,
+                'encryption_service' => EncryptionService::class,
+                'hashing_adapter'    => HashingAdapter::class,
+                'hashing_service'    => HashingService::class,
+            ],
+            'factories' => [
+                EncryptionAdapter::class => EncryptionAdapterFactory::class,
+                EncryptionService::class => EncryptionServiceFactory::class,
+                HashingAdapter::class    => HashingAdapterFactory::class,
+                HashingService::class    => HashingServiceFactory::class,
+            ],
+        ];
+    }
+}

--- a/src/Factory/Service/EncryptionServiceFactory.php
+++ b/src/Factory/Service/EncryptionServiceFactory.php
@@ -20,7 +20,7 @@ class EncryptionServiceFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $config = $container->get('Config');
+        $config = $container->get('config');
 
         if ( ! isset($config['doctrine']['encryption']['orm_default'])) {
             throw new Exception(

--- a/src/Factory/Service/HashingServiceFactory.php
+++ b/src/Factory/Service/HashingServiceFactory.php
@@ -20,7 +20,7 @@ class HashingServiceFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $config = $container->get('Config');
+        $config = $container->get('config');
 
         if ( ! isset($config['doctrine']['hashing']['orm_default'])) {
             throw new Exception(

--- a/src/Factory/Subscriber/EncryptionSubscriberFactory.php
+++ b/src/Factory/Subscriber/EncryptionSubscriberFactory.php
@@ -60,7 +60,7 @@ class EncryptionSubscriberFactory extends AbstractFactory
      *
      * @return string
      */
-    public function getOptionsClass()
+    public function getOptionsClass(): string
     {
         return EncryptionOptions::class;
     }

--- a/src/Factory/Subscriber/HashingSubscriberFactory.php
+++ b/src/Factory/Subscriber/HashingSubscriberFactory.php
@@ -62,7 +62,7 @@ class HashingSubscriberFactory extends AbstractFactory
      *
      * @return string
      */
-    public function getOptionsClass()
+    public function getOptionsClass(): string
     {
         return HashingOptions::class;
     }


### PR DESCRIPTION
I have added a ConfigProvider to use in Mezzio.
There was a dependency on DoctrineModule in the subscriber factories, this is now added to the composer.json.
The function return type declaration of `getOptionsClass` was changed to match the `DoctrineModule\Service\AbstractFactory`.
Using the ServiceManager "Config" was problematic, I had to change this to "config".
The Doctrine event manager uses the key "event_manager" instead of "eventmanager", I have corrected this.
The readme is updated for use with Mezzio.