### PR TITLE
Feature/update hashes when hashed value changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ When using Mezzio, you will want to add the ConfigProvider to your `config/confi
     \Keet\Encrypt\ConfigProvider::class,
 ```
 
-When declaring the path to your entities, be sure to pass the path(s) as an array.
+When declaring the path to your entities (likely the file with `App\ConfigProvider`), be sure to pass the path(s) as an array.
 ```
     'my_entity' => [
         'class' => AnnotationDriver::class,

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^7.3",
+        "php": " ~7.2 || 8.0.*",
         "ext-sodium": "*",
         "doctrine/annotations": "^1.6",
         "doctrine/orm": "^2.6",

--- a/src/Subscriber/HashingSubscriber.php
+++ b/src/Subscriber/HashingSubscriber.php
@@ -223,7 +223,15 @@ class HashingSubscriber implements EventSubscriber
                         'nullable'   => $meta->getFieldMapping($refProperty->getName())['nullable'],
                     ];
                 } else if ($arrayKeyExists) {
-                    $refProperty->setValue($entity, $entityChangeSet[$refProperty->getName()][0]);
+                    // If the hashed value does not match the new value, then use a new hash, else use the old hash
+                    $oldHashedValue = $entityChangeSet[$refProperty->getName()][0];
+                    $newNonHashedValue = $entityChangeSet[$refProperty->getName()][1];
+                    $valueIsChanged = $this->getHashor()->verify($newNonHashedValue, $oldHashedValue) === false;
+                    if ($valueIsChanged) {
+                        $refProperty->setValue($entity, $this->getHashor()->hash($newNonHashedValue));
+                    } else {
+                        $refProperty->setValue($entity, $entityChangeSet[$refProperty->getName()][0]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
When a value is updated in a hashed property, that value is hashed and checked against the stored hash. If the hashes do not match, the new hash is stored in the entity.
Special thanks to Malika Wakrim.