### PR TITLE
Fix dependencies to allow install with php 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,15 @@
     "require": {
         "php": " ~7.2 || 8.0.*",
         "ext-sodium": "*",
-        "doctrine/annotations": "^1.6",
-        "doctrine/orm": "^2.6",
-        "doctrine/doctrine-module": "^4.1.1",
-        "paragonie/halite": "^4.4",
-        "paragonie/hidden-string": "^1.0",
-        "laminas/laminas-modulemanager": "^2.8",
-        "laminas/laminas-servicemanager": "^2.7.8 || ^3.3",
-        "laminas/laminas-stdlib": "^3.2",
-        "laminas/laminas-dependency-plugin": "^2.0.0"
+        "doctrine/annotations": "^1.10.3",
+        "doctrine/orm": "^2.8",
+        "doctrine/doctrine-module": "^4.1.2",
+        "paragonie/halite": "^4.7",
+        "paragonie/hidden-string": "^1.1",
+        "laminas/laminas-modulemanager": "^2.10",
+        "laminas/laminas-servicemanager": "^2.7.8 || ^3.6",
+        "laminas/laminas-stdlib": "^3.3",
+        "laminas/laminas-dependency-plugin": "^2.0 || ^2.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Although the package declares php8 compat the majority of require dependencies were not targeting php8. All dependencies now target php7.2+ and php8.0